### PR TITLE
feat: Save new/changed behavior on the robot through SSH

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,14 @@
 {
-  "name": "FlexBE App",
-  "version": "2.0.7",
+  "name": "flexbe_app",
+  "version": "2.1.0",
   "main": "src/main.js",
+  "description": "flexbe_app provides a user interface (editor + runtime control) for the FlexBE behavior engine.",
+  "license": "BSD-3-Clause",
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:FlexBE/flexbe_app.git"
+  },
+  "readme": "README.md",
   "window": {
     "icon": "src/img/icon-128.png",
     "toolbar": false,
@@ -9,5 +16,8 @@
     "height": 830,
     "min_width": 1340,
     "min_height": 650
+  },
+  "dependencies" : {
+    "scp2" : "^0.5.0"
   }
 }

--- a/src/events.js
+++ b/src/events.js
@@ -119,6 +119,10 @@ document.addEventListener('DOMContentLoaded', function() {
     document.getElementById('select_default_package').addEventListener('change', UI.Settings.defaultPackageChanged);
     document.getElementById('select_code_indentation').addEventListener('change', UI.Settings.codeIndentationChanged);
     document.getElementById('input_editor_command').addEventListener('change', UI.Settings.editorCommandChanged);
+    document.getElementById('cb_save_on_robot').addEventListener('change', UI.Settings.saveOnRobotClicked);
+    document.getElementById('input_ssh_user_name').addEventListener('change', UI.Settings.sshUsernameChanged);
+    document.getElementById('input_ssh_host_name').addEventListener('change', UI.Settings.sshHostnameChanged);
+
 
     document.getElementById('select_transition_mode').addEventListener('change', UI.Settings.transitionEndpointsChanged);
     document.getElementById('input_gridsize').addEventListener('change', UI.Settings.gridsizeChanged);

--- a/src/io/io_behaviorsaver.js
+++ b/src/io/io_behaviorsaver.js
@@ -59,13 +59,89 @@ IO.BehaviorSaver = new (function() {
 		}
 	}
 
+    String.prototype.format = function() {
+        var formatted = this;
+        for( var arg in arguments ) {
+            formatted = formatted.replace("{" + arg + "}", arguments[arg]);
+        }
+        return formatted;
+    };
+
 	var saveSuccessCallback = function() {
 		T.logInfo("Save successful!");
 		UI.Panels.Terminal.hide();
 		UI.Settings.updateBehaviorlib();
 		UI.Tools.notifyRosCommand('save');
-	}
+    }
 
+    var saveOnRobot = function() {
+        var names = Behavior.createNames();
+        var package_name = names.rosnode_name;
+        var ssh_username = UI.Settings.getRobotUsername();
+        var ssh_hostname = UI.Settings.getRobotHostname();
+        var ssh_package_path = ""
+
+        if(ssh_username === "" || ssh_hostname === "" /*|| ssh_password === ""*/) {
+            T.logError("SSH configurations are not well defined, fix them from Configuration Tab -> Code Generation Box");
+            return;
+        }
+
+        var ssh_password = window.prompt("Please enter {0}:{1} password: ".format(ssh_username, ssh_hostname));
+        if(ssh_password == null || ssh_password == "") {
+            return;
+        }
+
+        ROS.getPackagePath(package_name, (package_path) =>
+        {
+            try
+            {
+                var SSHClient = require('ssh2').Client;
+                conn = new SSHClient();
+                conn.on('ready', function() {
+                  var ros_distro = process.env.ROS_DISTRO;
+                  conn.exec('bash -c "source .profile && rospack find {1}"'.format(ros_distro, package_name), function(err, stream) {
+                    if (err) {
+                        T.logError(err);
+                    }
+                    stream.on('close', function(code, signal) {
+                      conn.end();
+                    })
+                    .on('data', function(remote_package_path) {
+                      ssh_package_path = remote_package_path;
+                      T.logInfo('Path to package on the robot: ' + ssh_package_path);
+                      conn.end()
+                      var scp_client = require('scp2')
+                      var ssh_query = '{0}:{1}@{2}:{3}/'.format(
+                          ssh_username,
+                          ssh_password,
+                          ssh_hostname,
+                          ssh_package_path).replace(/\s+/, "");
+                      scp_client.scp(package_path+"/", String(ssh_query), function(err) {
+                        var err_str = String(err);
+                        if( err_str != 'undefined') {
+                            T.logError("scp failed "+err);
+                        }
+                      });
+                    }).stderr.on('data', function(data) {
+                      T.logError(data+", Make sure robot's ROS environment is configured properly in \".profile\" script");
+                    })
+                  });
+                })
+                .on('error', function(err) {
+                        T.logError(err);
+                        T.logError("Please check your ssh configuration and entered password.");
+                 })
+                 .connect({
+                  host: ssh_hostname,
+                  username: ssh_username,
+                  password: ssh_password
+                });
+            }
+            catch(ex) {
+                T.logError("An exception occurred: "+ex.message+", Make sure you installed the dependencies properly!")
+            }
+        })
+    }
 
 	this.saveStateMachine = function() {
 		T.clearLog();
@@ -97,8 +173,12 @@ IO.BehaviorSaver = new (function() {
 				// make sure code file exists before creating the manifest
 				// this reduces the risk for orphan manifests
 				storeBehaviorManifest(generated_manifest, () => {
-					saveSuccessCallback();
-				});
+                    if(UI.Settings.isSaveOnRobotEnabled()) {
+                        //Save/Overwrite the behavior on the robot
+                        saveOnRobot();
+                    }
+                    saveSuccessCallback();
+        		});
 			});
 		});
 	}

--- a/src/io/io_behaviorsaver.js
+++ b/src/io/io_behaviorsaver.js
@@ -168,19 +168,19 @@ IO.BehaviorSaver = new (function() {
 				return;
 			}
 
-			// store in file
-			storeBehaviorCode(generated_code, () => {
-				// make sure code file exists before creating the manifest
-				// this reduces the risk for orphan manifests
-				storeBehaviorManifest(generated_manifest, () => {
+            // store in file
+            storeBehaviorCode(generated_code, () => {
+                // make sure code file exists before creating the manifest
+                // this reduces the risk for orphan manifests
+                storeBehaviorManifest(generated_manifest, () => {
                     if(UI.Settings.isSaveOnRobotEnabled()) {
                         //Save/Overwrite the behavior on the robot
                         saveOnRobot();
                     }
                     saveSuccessCallback();
-        		});
-			});
-		});
-	}
+                });
+            });
+        });
+    }
 
 }) ();

--- a/src/ui/ui_settings.js
+++ b/src/ui/ui_settings.js
@@ -17,6 +17,9 @@ UI.Settings = new (function() {
 	var default_package;
 	var code_indentation;
 	var editor_command;
+	var save_on_robot;
+	var ssh_hostname;
+	var ssh_username;
 
 	var transition_mode;
 	var gridsize;
@@ -42,6 +45,9 @@ UI.Settings = new (function() {
 			'default_package': default_package,
 			'code_indentation': code_indentation,
 			'editor_command': editor_command,
+			'save_on_robot': save_on_robot,
+			'ssh_username' : ssh_username,
+			'ssh_hostname' : ssh_hostname,
 			'transition_mode': transition_mode,
 			'gridsize': gridsize,
 			'commands_enabled': commands_enabled,
@@ -69,6 +75,9 @@ UI.Settings = new (function() {
 			'default_package': 'flexbe_behaviors',
 			'code_indentation': 0,
 			'editor_command': 'gedit --new-window $FILE +$LINE',
+			'save_on_robot' : false,
+			'ssh_username': "",
+			'ssh_hostname' : "",
 			'transition_mode': 1,
 			'gridsize': 50,
 			'commands_enabled': false,
@@ -101,6 +110,16 @@ UI.Settings = new (function() {
 			document.getElementById("select_code_indentation").selectedIndex = items.code_indentation;
 			editor_command = items.editor_command;
 			document.getElementById("input_editor_command").value = items.editor_command;
+			save_on_robot = items.save_on_robot;
+            document.getElementById("cb_save_on_robot").checked = items.save_on_robot;
+            ssh_username = items.ssh_username;
+            document.getElementById("input_ssh_user_name").value = items.ssh_username;
+            ssh_hostname = items.ssh_hostname;
+            document.getElementById("input_ssh_host_name").value = items.ssh_hostname;
+            document.getElementById("input_ssh_user_name").disabled = !items.save_on_robot;
+            document.getElementById("input_ssh_host_name").disabled = !items.save_on_robot;
+
+
 
 			transition_mode = items.transition_mode;
 			document.getElementById("select_transition_mode").selectedIndex = items.transition_mode;
@@ -439,6 +458,33 @@ UI.Settings = new (function() {
 	this.getEditorCommand = function(file_path, line_number) {
 		if (line_number == undefined) line_number = 0;
 		return editor_command.replace("$LINE", line_number).replace("$FILE", file_path);
+	}
+
+    this.isSaveOnRobotEnabled = function() { return save_on_robot; }
+
+    this.saveOnRobotClicked = function(evt) {
+        save_on_robot = evt.target.checked;
+        storeSettings();
+        document.getElementById("input_ssh_user_name").disabled = !save_on_robot;
+        document.getElementById("input_ssh_host_name").disabled = !save_on_robot;
+    }
+
+    this.sshUsernameChanged = function(evt) {
+        ssh_username = document.getElementById('input_ssh_user_name').value;
+        storeSettings();
+    }
+
+    this.sshHostnameChanged = function(evt) {
+        ssh_hostname = document.getElementById('input_ssh_host_name').value;
+        storeSettings();
+    }
+
+    this.getRobotHostname = function() {
+        return document.getElementById('input_ssh_host_name').value;
+    }
+
+	this.getRobotUsername = function() {
+	    return document.getElementById('input_ssh_user_name').value;
 	}
 
 

--- a/src/ui/ui_settings.js
+++ b/src/ui/ui_settings.js
@@ -483,9 +483,9 @@ UI.Settings = new (function() {
         return document.getElementById('input_ssh_host_name').value;
     }
 
-	this.getRobotUsername = function() {
-	    return document.getElementById('input_ssh_user_name').value;
-	}
+    this.getRobotUsername = function() {
+        return document.getElementById('input_ssh_user_name').value;
+    }
 
 
 	// Editor

--- a/src/window.html
+++ b/src/window.html
@@ -502,6 +502,18 @@
 					<td width="150">Editor command: </td>
 					<td><input id="input_editor_command" type="text" class="input_field" /></td>
 				</tr>
+				<tr title="If this option is enabled, the generated code will be uploaded on the robot using a SSH tunnel">
+					<td width="80">Save on the robot: </td>
+					<td><input id="cb_save_on_robot" type="checkbox" /></td>
+				</tr>
+				<tr title="Hostname which is required for creating a SSH connection">
+					<td width="100">Robot hostname: </td>
+					<td><input id="input_ssh_host_name" type="text" class="input_field" disabled/></td>
+				</tr>
+				<tr title="Username which is required for creating a SSH connection">
+					<td width="100">Robot username: </td>
+					<td><input id="input_ssh_user_name" type="text" class="input_field" disabled/></td>
+				</tr>
 			</table>
 		</div>
 


### PR DESCRIPTION
## What I did:
- Used [scp2](https://github.com/spmjs/node-scp2) and [ssh2](https://github.com/mscdex/ssh2) node modules to update the behavior package on the robot according to new changes made on this package (adding new behavior, modifying an existing one) through SSH.
- The SSH configurations (hostname and username) shall be set in new input boxes provided in **Code Generation** section of **Configuration** tab. This feature is **disabled** by default and it can be set to enabled from the same section.
![screenshot from 2018-06-03 13-27-16](https://user-images.githubusercontent.com/2716644/40886076-ecb27536-6731-11e8-8ae2-94976c60e8d2.png)

- For security reasons (to don't store them in cookies) password will be prompted on clicking the **save behavior** button.
![image](https://user-images.githubusercontent.com/2716644/40886078-ff2a760a-6731-11e8-9cb8-3c379a64910b.png)
- Refactored the **package.json** and added dependency to **scp2** module. 

## Important notes:
- The behavior package **shall** be already available on the robot.
- In order to be able to find package the path, the ROS environment variables shall be set properly on **.profile** script. 
- In order to use this new feature its dependencies needs to be install by entering `npm install` in the root directory of **flexbe_app** package.
- If you saw any indentation incossitency, its because of using tabs instead of spaces in the whole original source code, while I used 4-spaces. This shall be fixed in a separate PR.
## Feature works:
- Unfortunately, javascript doesn't provide a prompt box with password masking feature, as a matter of the fact, the current password prompt is unmasked. A proper solution is to replace the usage of the password with SSH keys.
- Currently, the whole package will be overwritten by clicking on save behavior. This can be improved by just updating the modified files. 