### PR TITLE
Add cmake install rules and use rospack to find nw executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,3 +41,51 @@ add_custom_target(nw_install DEPENDS nw)
 if(NOT ${CMAKE_CURRENT_SOURCE_DIR}/nw)
   safe_execute_process(COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/bin/nwjs_install)
 endif()
+
+#############
+## Install ##
+#############
+
+# all install targets should use catkin DESTINATION variables
+# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
+
+# call catkin_destinations() to populate CATKIN_*_DESTINATION cmake variables
+catkin_destinations()
+
+install(DIRECTORY
+  launch
+  src
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
+install(PROGRAMS
+  bin/run_app
+  bin/shortcut
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(DIRECTORY
+  lib
+  locales
+  swiftshader
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+  USE_SOURCE_PERMISSIONS
+)
+
+install(FILES
+  credits.html
+  flexbe.desktop
+  icudtl.dat
+  natives_blob.bin
+  nw_100_percent.pak
+  nw_200_percent.pak
+  package.json
+  resources.pak
+  snapshot_blob.bin
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
+install(PROGRAMS
+  nw
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/bin/run_app
+++ b/bin/run_app
@@ -1,11 +1,11 @@
 #!/bin/bash
-cd "$( dirname "${BASH_SOURCE[0]}" )"
 
-if [ ! -f ../nw ]; then
+NW="$(rospack find flexbe_app)/nw"
+if [ ! -x "${NW}" ]; then
   echo "Cannot run flexbe_app, need to download nwjs first."
   echo "Please build flexbe_app via catkin before using it or run the following command now:"
   echo "  rosrun flexbe_app nwjs_install"
   exit -1
 fi
 
-../nw --password-store=basic $*
+"$NW" --password-store=basic "$@"

--- a/bin/shortcut
+++ b/bin/shortcut
@@ -1,10 +1,10 @@
 #!/bin/bash
-if [ $1 == "create" ] ; then
-	cd "$( dirname "${BASH_SOURCE[0]}" )"/..
+if [ "$1" == "create" ] ; then
+	cd $(rospack find flexbe_app)
 	cp flexbe.desktop ~/.local/share/applications
 	cp src/img/icon-128.png ~/.local/share/icons/flexbe_app.png
 	echo "Launcher shortcut created"
-elif [ $1 == "remove" ] ; then
+elif [ "$1" == "remove" ] ; then
 	rm ~/.local/share/applications/flexbe.desktop
 	rm ~/.local/share/icons/flexbe_app.png
 	echo "Launch shortcut removed"

--- a/package.xml
+++ b/package.xml
@@ -15,5 +15,6 @@
   <run_depend>rospy</run_depend>
   <run_depend>genpy</run_depend>
   <run_depend>actionlib</run_depend>
+  <run_depend>rospack</run_depend>
 
 </package>


### PR DESCRIPTION
This PR adds install rules to `CMakeLists.txt` that allow to run the FlexBE App from an install-space.

To make it work I had to replace the search paths relative to the location of the `run_app` and `shortcut` scripts by calls to `rospack find`. `rospack` is a dependency anyway because it's called from [src/ros/ros.js:53](https://github.com/meyerj/flexbe_app/blob/16d0cd474ca969ec10598d1e2bdacd5fef66181d/src/ros/ros.js#L53).