### PR TITLE
implementing ROS.getPackagePythonPath

### DIFF
--- a/src/ros/ros.js
+++ b/src/ros/ros.js
@@ -90,6 +90,26 @@ rospy.spin()
 		});
 	}
 
+	that.getPackagePythonPath = function(package_name, callback) {
+		var proc = spawn('python', ['-c', 'import '+package_name+'; print('+package_name+'.__path__)']);
+
+		var path_data = '';
+		proc.stdout.on('data', data => {
+			path_data += data;
+		});
+		proc.stderr.on('data', data => {
+			console.log(package_name+" failed to import: "+data);
+		});
+		proc.on('close', (code) => {
+			try {
+				var path_list = JSON.parse(path_data.replace(/'/g, '"'));
+				callback(path_list[path_list.length-1]);
+			} catch (err) {
+				callback(undefined);
+			}
+		});
+	}
+
 	// that.getParam = function(name, callback) {
 	// 	var proc = spawn('rosparam', ['get', name]);
 	// 	proc.stdout.on('data', data => {

--- a/src/ui/ui_dashboard.js
+++ b/src/ui/ui_dashboard.js
@@ -1225,6 +1225,7 @@ UI.Dashboard = new (function() {
 
 	this.resetAllFields = function() {
 		UI.Settings.createBehaviorPackageSelect(document.getElementById('select_behavior_package'));
+		Behavior.setBehaviorPackage(UI.Settings.getDefaultPackage());
 		document.getElementById('input_behavior_name').value = "";
 		document.getElementById('input_behavior_description').value = "";
 		document.getElementById('input_behavior_tags').value = "";


### PR DESCRIPTION
ROS.getPackagePythonPath wasn't implemented, so errors were thrown when attempting to save a behavior.  I basically copied the private method in IO.PackageParser named getPythonPath.  The return value is the last element of the python search path, which works out to the install path (in install space mode) and the src path (in devel space mode).