### PR TITLE
Check that package.xml exists before trying to read it. 

### DIFF
--- a/src/io/io_packageparser.js
+++ b/src/io/io_packageparser.js
@@ -58,19 +58,19 @@ IO.PackageParser = new (function() {
 	}
 
 	var checkForRelevance = function(pkg_path, callback) {
-            package_xml_path = path.join(pkg_path, 'package.xml');
-
-            if (fs.existsSync(package_xml_path)) {
-                var data = fs.readFileSync(package_xml_path);
-                var xml = dom_parser.parseFromString(String(data), "text/xml");
-		var pkg_xml = xml.getElementsByTagName("package")[0];
-		var pkg_export = pkg_xml.getElementsByTagName("export")[0];
-		var hasStates = pkg_export && pkg_export.getElementsByTagName("flexbe_states").length > 0;
-		var hasBehaviors = pkg_export && pkg_export.getElementsByTagName("flexbe_behaviors").length > 0;
-		callback(hasStates, hasBehaviors);
-            } else {
-                callback(undefined, undefined);
-            }
+		var package_xml_path = path.join(pkg_path, 'package.xml');
+		
+		if (fs.existsSync(package_xml_path)) {
+			var data = fs.readFileSync(package_xml_path);
+			var xml = dom_parser.parseFromString(String(data), "text/xml");
+			var pkg_xml = xml.getElementsByTagName("package")[0];
+			var pkg_export = pkg_xml.getElementsByTagName("export")[0];
+			var hasStates = pkg_export && pkg_export.getElementsByTagName("flexbe_states").length > 0;
+			var hasBehaviors = pkg_export && pkg_export.getElementsByTagName("flexbe_behaviors").length > 0;
+			callback(hasStates, hasBehaviors);
+		} else {
+			callback(undefined, undefined);
+		}
 	}
 
 	var watchStateFolder = function(folder_path, import_path) {

--- a/src/io/io_packageparser.js
+++ b/src/io/io_packageparser.js
@@ -58,13 +58,19 @@ IO.PackageParser = new (function() {
 	}
 
 	var checkForRelevance = function(pkg_path, callback) {
-		var data = fs.readFileSync(path.join(pkg_path, 'package.xml'));
-		var xml = dom_parser.parseFromString(String(data), "text/xml");
+            package_xml_path = path.join(pkg_path, 'package.xml');
+
+            if (fs.existsSync(package_xml_path)) {
+                var data = fs.readFileSync(package_xml_path);
+                var xml = dom_parser.parseFromString(String(data), "text/xml");
 		var pkg_xml = xml.getElementsByTagName("package")[0];
 		var pkg_export = pkg_xml.getElementsByTagName("export")[0];
 		var hasStates = pkg_export && pkg_export.getElementsByTagName("flexbe_states").length > 0;
 		var hasBehaviors = pkg_export && pkg_export.getElementsByTagName("flexbe_behaviors").length > 0;
 		callback(hasStates, hasBehaviors);
+            } else {
+                callback(undefined, undefined);
+            }
 	}
 
 	var watchStateFolder = function(folder_path, import_path) {


### PR DESCRIPTION
Very old packages/stacks may not have a package.xml, but ROS will report them as existing packages. This will cause flexbe_app to fail silently and any packages left to be parsed will be skipped.

This patch addresses the issue by checking that package.xml exists before reading this. 

Just a note, I don't really know anything about javascript/Node.js so there may be a much better way of handling this, but it worked for my use case.