### PR TITLE
Add 'flexbe_behavior_engine' to package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -21,6 +21,7 @@
   <run_depend>genpy</run_depend>
   <run_depend>actionlib</run_depend>
   <run_depend>rospack</run_depend>
+  <run_depend>flexbe_behavior_engine</run_depend>
 
   <test_depend>rosunit</test_depend>
 


### PR DESCRIPTION
Helpfully as it allows ```rosdep install``` to resolve this dependency and automatically install the flexbe_behavior_engine package.