### PR TITLE
bugfix: avoid crash during Python state parsing on empty documentation

### DIFF
--- a/src/io/io_stateparser.js
+++ b/src/io/io_stateparser.js
@@ -279,6 +279,8 @@ for data in iter(sys.stdin.readline, ""):
 	}
 
 	var parseDocumentation = function(docstring) {
+	    if (typeof docstring != "string" || docstring == "")
+	        return new WS.Documentation("[no documentation]");
 		var state_desc = "";
 		var argument_doc = [];
 		var last_argument = undefined;


### PR DESCRIPTION
The Python state parsing feature introduced in 4f20227ef900ca32e78414c190fb464d964666e5 (great feature, by the way; thanks a lot for this!) used to crash when no docstring is provided in a state definition, hence stalling the parsing procedure. This commit returns the default label "[no documentation]" on a missing docstring.