### PR TITLE
regression bugfix: import/export configuration broken due to nw.js bug

### DIFF
--- a/bin/nwjs_install
+++ b/bin/nwjs_install
@@ -4,7 +4,7 @@ TEMPFILE="nwjs.tar.gz"
 mkdir -p ../nwjs
 cd ../nwjs
 
-VERSION="v0.43.5" # verified working, to be incremented explicitly
+VERSION="v0.42.3" # verified working, to be incremented explicitly
 
 # check if nw is already existing and up-to-date, abort if so
 if [ -f nw ]; then

--- a/src/ui/ui_settings.js
+++ b/src/ui/ui_settings.js
@@ -342,6 +342,9 @@ UI.Settings = new (function() {
 			}]
 		}, function(entry) {
 			if (chrome.runtime.lastError) {
+			    if (chrome.runtime.lastError.message.lastIndexOf('User', 0) != 0) {
+			        T.logError(chrome.runtime.lastError.message)
+				}
 				return;
 			}
 			UI.Panels.setActivePanel(UI.Panels.NO_PANEL);
@@ -368,6 +371,9 @@ UI.Settings = new (function() {
 			}]
 		}, function(entry) {
 			if (chrome.runtime.lastError) {
+			    if (chrome.runtime.lastError.message.lastIndexOf('User', 0) != 0) {
+			        T.logError(chrome.runtime.lastError.message)
+				}
 				return;
 			}
 			chrome.storage.local.get(null, function(config) {


### PR DESCRIPTION
The import/export configuration functionality silently fails since b93078f and simply does nothing when hitting the buttons. Digging deeper, it throws an "Invalid calling page. This function can't be called from a background page." error. 
The reason is a bug in nw.js already reported on nwjs/nw.js#7349 and happens from nw.js 0.42.4.
Hence, the import/export functionality is currently unusable with nw.js >0.42.3 as integrated in b93078f.

This bugfix therefore reverts the nw.js version to the last known-to-work one (0.42.3) and also adds a terminal error message to catch this regression in case it appears again.