### PR TITLE
check-behavior command line option

### DIFF
--- a/bin/test_report
+++ b/bin/test_report
@@ -15,6 +15,17 @@ class TestReport(unittest.TestCase):
 				if test_type == "assertTrue":
 					self.assertTrue(test_data, test_name)
 
+	def test_behavior_report(self):
+		try:
+			with open("/tmp/flexbe_app_behavior_report.log", 'r') as f:
+				report = yaml.safe_load(f)
+		except IOError:
+			return # skip test since there is no report to evaluate
+		for test_type, tests in report.items():
+			for test_name, test_data in tests.items():
+				if test_type == "assertTrue":
+					self.assertTrue(test_data, test_name)
+
 if __name__ == '__main__':
-    import rosunit
-    rosunit.unitrun("flexbe_app", "test_report", TestReport)
+	import rosunit
+	rosunit.unitrun("flexbe_app", "test_report", TestReport)

--- a/src/_test/checkbehaviorsreport.js
+++ b/src/_test/checkbehaviorsreport.js
@@ -1,0 +1,31 @@
+CheckBehaviorsReport = new (function() {
+
+    var report = {'assertTrue': {}};
+
+    this.checkAllBehaviors = function(callback) {
+        var behaviors = WS.Behaviorlib.getBehaviorList();
+
+        var next = function(){
+            if (behaviors.length == 0){
+                IO.Filesystem.createFile('/tmp', "flexbe_app_behavior_report.log", JSON.stringify(report), callback);
+            } else {
+                var behavior = behaviors.shift();
+                var m = WS.Behaviorlib.getByName(behavior).getBehaviorManifest();
+
+                IO.BehaviorLoader.loadBehavior(m, function(error_string) {
+                    console.log(error_string);
+                    if (error_string != undefined) {
+                        report.assertTrue["behavior_"+behavior] = false;
+                        console.log(behavior+" is false");
+                    }
+                    else{
+                        report.assertTrue["behavior_"+behavior] = true;
+                        console.log(behavior+" is true");
+                    }
+                    next();
+                });
+            }
+        }
+        next();
+    }
+})();

--- a/src/window.html
+++ b/src/window.html
@@ -6,7 +6,7 @@
 	<script src="ext/d3.min.js"></script>
 	<script src="ext/json_parse_raw.js"></script>
 	<script src="ext/yaml.min.js"></script>
-	
+
 	<script src="window.js"></script>
 
 	<script src="events.js"></script>
@@ -78,6 +78,7 @@
 	<script src="_test/scripts.js"></script>
 	<script src="_test/testreport.js"></script>
 	<script src="_test/statelib.test.js"></script>
+	<script src="_test/checkbehaviorsreport.js"></script>
 
 	<link rel="stylesheet" href="style/main.css" type="text/css" />
 	<link rel="stylesheet" href="style/dashboard.css" type="text/css" />
@@ -113,7 +114,7 @@
 			<div class="category_button" id="button_to_se"><img src="img/se.png" width="32" height="32" /> Configuration</div>
 		</td><td id="title_button_panel">
 
-		</td></tr></table>	
+		</td></tr></table>
 	</div>
 
 	<div id="flexbe_about" title="About FlexBE">
@@ -166,7 +167,7 @@
 
 	<div id="properties_autocomplete" class="sidepanel_autocomplete" style="display: none;" idx="0"></div>
 
-	<div id="dashboard"> 
+	<div id="dashboard">
 
 		<div class="box">
 			<h1>Overview</h1>
@@ -205,13 +206,13 @@
 			<table class="box_table"><tr><td>
 				<input id="input_db_variable_key_add" type="text" class="input_field" />
 			</td><td>
-				&nbsp;&nbsp;=&nbsp; 
+				&nbsp;&nbsp;=&nbsp;
 			</td><td width="60%">
 				<input id="input_db_variable_value_add" type="text" class="input_field" />
 			</td><td>
 				<input id="button_db_variable_add" type="button" value="Add" />
 			</td></tr></table>
-			
+
 		</div>
 
 		<div class="box">
@@ -221,7 +222,7 @@
 			<table class="box_table"><tr><td>
 				<input id="input_db_userdata_key_add" type="text" class="input_field" />
 			</td><td>
-				&nbsp;&nbsp;=&nbsp; 
+				&nbsp;&nbsp;=&nbsp;
 			</td><td>
 				<input id="input_db_userdata_value_add" type="text" class="input_field" />
 			</td><td>
@@ -637,25 +638,25 @@
 			<div id="panel_prop_parameters" class="sidepanel_category">
 				<b>Parameters</b>
 				<table id="panel_prop_parameters_content" class="sidepanel_table">
-					
+
 				</table>
 			</div>
 			<div id="panel_prop_autonomy" class="sidepanel_category">
 				<b>Required Autonomy Levels</b>
 				<table id="panel_prop_autonomy_content" class="sidepanel_table">
-					
+
 				</table>
 			</div>
 			<div id="panel_prop_input_keys" class="sidepanel_category">
 				<b>Input Key Mapping</b>
 				<table id="panel_prop_input_keys_content" class="sidepanel_table">
-					
+
 				</table>
 			</div>
 			<div id="panel_prop_output_keys" class="sidepanel_category">
 				<b>Output Key Mapping</b>
 				<table id="panel_prop_output_keys_content" class="sidepanel_table">
-					
+
 				</table>
 			</div>
 
@@ -683,26 +684,26 @@
 			<div id="panel_prop_be_parameters" class="sidepanel_category">
 				<b>Parameters</b>
 				<table id="panel_prop_be_parameters_content" class="sidepanel_table">
-					
+
 				</table>
 			</div>
 
 			<div id="panel_prop_be_autonomy" class="sidepanel_category">
 				<b>Required Autonomy Levels</b>
 				<table id="panel_prop_be_autonomy_content" class="sidepanel_table">
-					
+
 				</table>
 			</div>
 			<div id="panel_prop_be_input_keys" class="sidepanel_category">
 				<b>Input Key Mapping</b>
 				<table id="panel_prop_be_input_keys_content" class="sidepanel_table">
-					
+
 				</table>
 			</div>
 			<div id="panel_prop_be_output_keys" class="sidepanel_category">
 				<b>Output Key Mapping</b>
 				<table id="panel_prop_be_output_keys_content" class="sidepanel_table">
-					
+
 				</table>
 			</div>
 
@@ -716,7 +717,7 @@
 				<input id="input_prop_sm_name" class="inline_title_text_edit" type="text" />
 			</div>
 			<div style="font-style: italic; padding: 0px 5px; margin-top: 5px; color: gray;">
-				Type: 
+				Type:
 				<select id="select_container_type">
 					<option value="statemachine">Statemachine</option>
 					<option value="concurrency">Concurrency</option>
@@ -754,7 +755,7 @@
 			<div id="panel_prop_sm_autonomy" class="sidepanel_category">
 				<b>Outcomes</b>
 				<table id="panel_prop_sm_outcomes_content" class="sidepanel_table">
-					
+
 				</table>
 				<table class="sidepanel_table"><tr><td>
 					<input id="input_prop_outcome_add" type="text" class="input_field" />
@@ -765,7 +766,7 @@
 			<div id="panel_prop_sm_input_keys" class="sidepanel_category">
 				<b>Input Keys</b>
 				<table id="panel_prop_sm_input_keys_content" class="sidepanel_table">
-					
+
 				</table>
 				<table class="sidepanel_table"><tr><td>
 					<input id="input_prop_input_key_add" type="text" class="input_field" />
@@ -776,7 +777,7 @@
 			<div id="panel_prop_sm_output_keys" class="sidepanel_category">
 				<b>Output Keys</b>
 				<table id="panel_prop_sm_output_keys_content" class="sidepanel_table">
-					
+
 				</table>
 				<table class="sidepanel_table"><tr><td>
 					<input id="input_prop_output_key_add" type="text" class="input_field" />
@@ -829,7 +830,7 @@
 		<div class="sidepanel_title_text">
 			Select Behavior
 		</div>
-		
+
 		<div class="sidepanel_category">
 			<table class="sidepanel_table">
 				<tr>
@@ -851,7 +852,7 @@
 	</div>
 
 	<div id="terminal">
-		
+
 	</div>
 
 	<div class="emptypage">
@@ -859,7 +860,7 @@
 	</div>
 
 	<div id="add_state_panel" style="display: none; position: absolute; top: 100px; left: 100px; background-color: white; border: 1px solid black;">
-		
+
 	</div>
 
 	<div id="tool_overlay">

--- a/src/window.js
+++ b/src/window.js
@@ -2,7 +2,7 @@ window.onload = function() {
 	var gui = require('nw.gui');
 
 	Behavior.resetBehavior();
-	
+
 	// Initialize gui panel
 	UI.Statemachine.initialize();
 	UI.Menu.toDashboardClicked();
@@ -11,7 +11,7 @@ window.onload = function() {
 	UI.Dashboard.addBehaviorOutcome('failed');
 	ActivityTracer.resetActivities();
 	UI.RuntimeControl.displayLockBehavior();
-	
+
 	RC.Controller.initialize();
 
 	// Initialize runtime control
@@ -29,6 +29,12 @@ window.onload = function() {
 	if (gui.App.argv.contains('--run-tests')) {
 		setTimeout(() => {
 			TestReport.runAllTests(status =>  gui.App.quit());
+		}, 5 * 1000);
+	}
+
+	else if (gui.App.argv.contains('--check-behaviors')) {
+		setTimeout(() => {
+			CheckBehaviorsReport.checkAllBehaviors(gui.App.quit);
 		}, 5 * 1000);
 	}
 }


### PR DESCRIPTION
I've added a new command line option `--check-behavior` which will load all available behaviors sequentially and writes the checkBehavior outcome to a test report file (same way as the `--run-test` parameter). With that the flexbe_app checkBehavior feature can be integrated into CI like it is done [here](https://github.com/FlexBE/flexbe_ci/blob/51096dfc4f1f0cc590fa862bc4ce36381073e2bc/ci_scripts/script.bash#L19).

solves https://github.com/FlexBE/flexbe_app/issues/54