### PR TITLE
Record and log errors when parsing states with Python

### DIFF
--- a/src/io/io_stateparser.js
+++ b/src/io/io_stateparser.js
@@ -266,7 +266,7 @@ for data in iter(sys.stdin.readline, ""):
 					[].concat(state_def['state_params_values']),
 					[].concat(state_def['state_autonomy']),
 					[].concat(state_def['class_vars'],
-					state_def['errors'])
+					state_def['error'])
 				));
 			} else {
 				callback(undefined);

--- a/src/io/io_stateparser.js
+++ b/src/io/io_stateparser.js
@@ -41,8 +41,11 @@ for data in iter(sys.stdin.readline, ""):
 			EventState.__init__ = __event_init
 			try:
 				cls(*args)
-			except Exception:
-				pass  # above will raise error, but in the best case, we updated state_def
+			except NotImplementedError:
+				pass  # above will raise NotImplementedError by design, but in the best case, we updated state_def
+			except Exception as e:   # In any other case, the user messed up perhaps?
+				import traceback
+				state_def['error'] = traceback.format_exc(e)
 			state_def['class_vars'] = [n for n, t in cls.__dict__.items()
 				if not inspect.isfunction(t) and not n.startswith('__')]
 			state_defs.append(state_def)

--- a/src/io/io_stateparser.js
+++ b/src/io/io_stateparser.js
@@ -270,7 +270,7 @@ for data in iter(sys.stdin.readline, ""):
 						state_def['error'])
 					));
 				} else { 
-					console.error("Error in " + state_def['state_class'] + ": " + state_def['error']);
+					T.logError("Error in " + state_def['state_class'] + ": " + state_def['error']);
 					callback(undefined)
 				}
 			} else {

--- a/src/io/io_stateparser.js
+++ b/src/io/io_stateparser.js
@@ -255,19 +255,24 @@ for data in iter(sys.stdin.readline, ""):
 					state_def['state_input'] = ['$' + state_def['state_input']];
 				if (typeof state_def['state_output'] == "string")
 					state_def['state_output'] = ['$' + state_def['state_output']];
-				callback(new WS.StateDefinition(
-					state_def['state_class'],
-					parseDocumentation(state_def['state_doc']),
-					import_path,
-					[].concat(state_def['state_params']),
-					[].concat(state_def['state_outcomes']),
-					[].concat(state_def['state_input']),
-					[].concat(state_def['state_output']),
-					[].concat(state_def['state_params_values']),
-					[].concat(state_def['state_autonomy']),
-					[].concat(state_def['class_vars'],
-					state_def['error'])
-				));
+				if(!state_def.hasOwnProperty('error')) {
+					callback(new WS.StateDefinition(
+						state_def['state_class'],
+						parseDocumentation(state_def['state_doc']),
+						import_path,
+						[].concat(state_def['state_params']),
+						[].concat(state_def['state_outcomes']),
+						[].concat(state_def['state_input']),
+						[].concat(state_def['state_output']),
+						[].concat(state_def['state_params_values']),
+						[].concat(state_def['state_autonomy']),
+						[].concat(state_def['class_vars'],
+						state_def['error'])
+					));
+				} else { 
+					console.error("Error in " + state_def['state_class'] + ": " + state_def['error']);
+					callback(undefined)
+				}
 			} else {
 				callback(undefined);
 			}

--- a/src/io/io_stateparser.js
+++ b/src/io/io_stateparser.js
@@ -235,7 +235,8 @@ for data in iter(sys.stdin.readline, ""):
 			state_output,
 			state_params_values,
 			state_autonomy,
-			class_vars
+			class_vars,
+			""  // Errors, but regex parser doesn't detect errors
 		));
 	}
 
@@ -264,7 +265,8 @@ for data in iter(sys.stdin.readline, ""):
 					[].concat(state_def['state_output']),
 					[].concat(state_def['state_params_values']),
 					[].concat(state_def['state_autonomy']),
-					[].concat(state_def['class_vars'])
+					[].concat(state_def['class_vars'],
+					state_def['errors'])
 				));
 			} else {
 				callback(undefined);

--- a/src/ws/ws_statedefinition.js
+++ b/src/ws/ws_statedefinition.js
@@ -1,4 +1,4 @@
-WS.StateDefinition = function(state_class, state_desc, state_path, parameters, outcomes, input_keys, output_keys, parameter_values, autonomy, class_vars) {
+WS.StateDefinition = function(state_class, state_desc, state_path, parameters, outcomes, input_keys, output_keys, parameter_values, autonomy, class_vars, errors) {
 	var that = this;
 
 	var state_class = state_class;
@@ -12,6 +12,7 @@ WS.StateDefinition = function(state_class, state_desc, state_path, parameters, o
 	var default_parameter_values = parameter_values;
 	var default_autonomy = autonomy;
 	var class_vars = class_vars;
+	var errors = errors;
 	var file_path = undefined;
 
 	this.setFilePath = function(_file_path) { file_path = _file_path; }
@@ -38,5 +39,7 @@ WS.StateDefinition = function(state_class, state_desc, state_path, parameters, o
 	this.getClassVariables = function() { return class_vars; }
 
 	this.getFilePath = function() { return file_path; }
+
+	this.getErrors = function() { return errors; }
 
 };


### PR DESCRIPTION
I made a typo while testing the subclassing of `EventState` (which works great in itself, saving a lot of code duplication!), causing an error to be thrown during the Python parsing

This caused the state not to be shown and some other neither. 

This PR adds some basic logging for that but is lacking a way to tell the (superclass)state definition has an error. Currently the state doesn't appear in the menu but that is not ideal I guess.

TODO:
- [x] Tell user that state definition failed to parse in Python
