### PR TITLE
some catkin_lint fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,23 +3,7 @@ project(flexbe_app)
 
 find_package(catkin REQUIRED)
 
-## Uncomment this if the package has a setup.py. This macro ensures
-## modules and global scripts declared therein get installed
-## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
-#catkin_python_setup()
-
-# specify catkin-specific information
-# INCLUDE_DIRS - The exported include paths (i.e. cflags) for the package
-# LIBRARIES - The exported libraries from the project
-# CATKIN_DEPENDS - Other catkin projects that this project depends on
-# DEPENDS - Non-catkin CMake projects that this project depends on
-# CFG_EXTRAS - Additional configuration options 
-catkin_package(
-    INCLUDE_DIRS src
-    LIBRARIES ${PROJECT_NAME})
-
-# use add_library() or add_executable() as required
-#add_library(${PROJECT_NAME} ${${PROJECT_NAME}_SRCS})
+catkin_package()
 
 #add_custom_target(nwjs_inst)
 #add_custom_command(TARGET nwjs_inst POST_BUILD COMMAND bin/nwjs_install)
@@ -40,20 +24,22 @@ endif()
 ## Install ##
 #############
 
-INSTALL(PROGRAMS
+install(PROGRAMS
+    bin/nwjs_install
     bin/run_app
     bin/shortcut
+    bin/test_report
     DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
-INSTALL(FILES
+install(FILES
     package.json
     DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
-INSTALL(DIRECTORY
+install(DIRECTORY
     src
     DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
-INSTALL(DIRECTORY
+install(DIRECTORY
     nwjs
     DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
     USE_SOURCE_PERMISSIONS

--- a/package.xml
+++ b/package.xml
@@ -13,7 +13,6 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>curl</build_depend>
-  <build_depend>rostest</build_depend>
 
   <run_depend>libnss3-dev</run_depend>
 
@@ -30,5 +29,6 @@
   <run_depend>flexbe_msgs</run_depend>
 
   <test_depend>rosunit</test_depend>
+  <test_depend>rostest</test_depend>
 
 </package>


### PR DESCRIPTION
we use `catkin_lint -W 2 --strict --explain` on most of our repos...and we found some complaints from `flexbe_app`

there are still some reports left, which I don't know whether they should be handled or ignored via `--ignore uninstalled_script`:
```
flexbe_app: warning: file 'flexbe.desktop' is executable but not installed
     *         Your package contains a file that is marked as
     * executable but not         installed. If it is a script
     * intended to be run (e.g. with rosrun), it         will not work
     * outside the devel tree. If it is not an executable
     * script, you should fix the file permissions.
     * You can ignore this problem with --ignore uninstalled_script
flexbe_app: warning: file 'nwjs/nw' is executable but not installed
flexbe_app: warning: file 'nwjs/swiftshader/libEGL.so' is executable but not installed
flexbe_app: warning: file 'nwjs/swiftshader/libGLESv2.so' is executable but not installed
flexbe_app: warning: file 'nwjs/lib/libnw.so' is executable but not installed
flexbe_app: warning: file 'nwjs/lib/libnode.so' is executable but not installed
flexbe_app: warning: file 'nwjs/lib/libffmpeg.so' is executable but not installed
catkin_lint: checked 1 packages and found 7 problems
```

I'm open for discussion