### PR TITLE
fix: code generation for containers without outcomes

### DIFF
--- a/src/io/io_codegenerator.js
+++ b/src/io/io_codegenerator.js
@@ -220,11 +220,11 @@ IO.CodeGenerator = new (function() {
 			}
 			code += ws+ws+"# " + pos.join(", ") + "\n";
 			if (sm.isConcurrent()) {
-				code += ws+ws+ sm_name + " = ConcurrencyContainer(outcomes=['" + sm.getOutcomes().join("', '") + "']";
+				code += ws+ws+ sm_name + " = ConcurrencyContainer(outcomes=[" + sm.getOutcomes().map(x => "'" + x + "'").join(", ") + "]";
 			} else if (sm.isPriority()) {
-				code += ws+ws+ sm_name + " = PriorityContainer(outcomes=['" + sm.getOutcomes().join("', '") + "']";
+				code += ws+ws+ sm_name + " = PriorityContainer(outcomes=[" + sm.getOutcomes().map(x => "'" + x + "'").join(", ") + "]";
 			} else {
-				code += ws+ws+ sm_name + " = OperatableStateMachine(outcomes=['" + sm.getOutcomes().join("', '") + "']";
+				code += ws+ws+ sm_name + " = OperatableStateMachine(outcomes=[" + sm.getOutcomes().map(x => "'" + x + "'").join(", ") + "]";
 			}
 			if (sm.getInputKeys().length > 0) {
 				code += ", input_keys=['" + sm.getInputKeys().join("', '") + "']";


### PR DESCRIPTION
When creating a container that has no outcomes within a behavior, flexbe_app is generating a python code that gives an error next time the behavior is loaded. This occurs as the generated string is `"OperatableStateMachine(outcomes=[''])"` while it should be `"OperatableStateMachine(outcomes=[])"` . 

An example behavior can be found in the attachment:
[codegenerationtest.zip](https://github.com/FlexBE/flexbe_app/files/7152720/codegenerationtest.zip)

Same problem does not occur with the `getInputKeys()` & `getOutputKeys()` as their length is checked before appending those strings. Same approach can also be used for the `getOutcomes()` method as an alternative to the solution given in this PR.